### PR TITLE
actions.yml is added for github actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,30 @@
+
+name: Github Actions
+
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+      - 'release/**'
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-18.04
+
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Run Detekt
+        run: ./gradlew detekt --stacktrace
+      - name: Run Lint
+        run: ./gradlew ktlint --stacktrace
+      - name: Run Lint
+        run: ./gradlew lintDevDebug --stacktrace
+      - name: Run Spotless
+        run: ./gradlew spotlessCheck --stacktrace

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    name: Run Unit Tests
+    name: Pipeline
     runs-on: ubuntu-18.04
 
 
@@ -22,7 +22,7 @@ jobs:
           java-version: 1.8
       - name: Run Detekt
         run: ./gradlew detekt --stacktrace
-      - name: Run Lint
+      - name: Run Ktlint
         run: ./gradlew ktlint --stacktrace
       - name: Run Lint
         run: ./gradlew lintDevDebug --stacktrace


### PR DESCRIPTION
In order to trigger github action pipeline, we should push the .yml file to the default branch which is "develop" for us.  The actions.yml file is configured to run the pipeline (specified in .github/workflows/actions.yml) when a pr created to "develop", "master" and "release/**" branches 

Someone who has administrator authority should also follow the instruction below to add the rule which enforce the actions to be completed before accepting a pull-request.

https://help.github.com/en/github/administering-a-repository/enabling-required-status-checks