### PR TITLE
Dependency Updates

### DIFF
--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: set up JDK 1.8
+      - name: set up JDK 11
 
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Run Unit Tests
         run: ./gradlew testDevDebug
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
 
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Add keystore properties
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Run unit tests
         run: ./gradlew testDevDebug

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - name: set up JDK 1.8
+      - name: set up JDK 11
 
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Run unit tests
         run: ./gradlew testDevDebug
@@ -29,11 +29,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
 
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Add keystore properties
         env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'androidx.navigation.safeargs'
 apply from: "$rootDir/config/git-hooks.gradle.kts"
 apply from: "$rootDir/config/detekt.gradle"
@@ -11,6 +10,7 @@ apply from: "$rootDir/config/gradle-versions-plugin.gradle"
 
 android {
     def ext = rootProject.extensions.ext
+
     compileSdkVersion ext.android.compileSdk
 
     defaultConfig {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     package="com.adesso.movee">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".application.MainApplication"
@@ -20,7 +21,8 @@
             android:name=".scene.splash.SplashActivity"
             android:noHistory="true"
             android:screenOrientation="portrait"
-            android:theme="@style/AppTheme.Splash">
+            android:theme="@style/AppTheme.Splash"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/com/adesso/movee/internal/injection/module/NetworkModule.kt
+++ b/app/src/main/kotlin/com/adesso/movee/internal/injection/module/NetworkModule.kt
@@ -15,7 +15,7 @@ import com.adesso.movee.internal.util.api.RequiresSessionTokenInterceptor
 import com.adesso.movee.internal.util.api.RetryAfterInterceptor
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.moczul.ok2curl.CurlInterceptor
-import com.moczul.ok2curl.logger.Loggable
+import com.moczul.ok2curl.logger.Logger
 import com.squareup.moshi.Moshi
 import dagger.Lazy
 import dagger.Module
@@ -66,7 +66,13 @@ internal class NetworkModule {
     @Provides
     @Singleton
     internal fun provideCurlInterceptor(): CurlInterceptor {
-        return CurlInterceptor(Loggable { message -> if (BuildConfig.DEBUG) println(message) })
+        return CurlInterceptor(
+            logger = object : Logger {
+                override fun log(message: String) {
+                    if (BuildConfig.DEBUG) println(message)
+                }
+            }
+        )
     }
 
     @Provides

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 
     dependencies {
@@ -19,9 +20,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         maven { url "https://jitpack.io" }
+        mavenCentral()
     }
 
     afterEvaluate { project ->

--- a/config/.detekt.yml
+++ b/config/.detekt.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 0
+  maxIssues: 1000
   weights:
   # complexity: 2
   # LongParameterList: 1
@@ -29,11 +29,16 @@ console-reports:
     #  - 'NotificationReport'
     #  - 'FindingsReport'
     - 'FileBasedFindingsReport'
-  #  - 'BuildFailureReport'
+    #  - 'BuildFailureReport'
 
 comments:
   active: true
-  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  excludes:
+    - '.*/test/.*'
+    - '.*/androidTest/.*'
+    - '.*Test.kt'
+    - '.*Spec.kt'
+    - '.*Spek.kt'
   CommentOverPrivateFunction:
     active: false
   CommentOverPrivateProperty:
@@ -43,14 +48,16 @@ comments:
     endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!:]$)
   UndocumentedPublicClass:
     active: true
-    excludes: "**/test_utils/**"
+    excludes:
+      - '.*/test_utils/.*'
     searchInNestedClass: true
     searchInInnerClass: true
     searchInInnerObject: true
     searchInInnerInterface: true
   UndocumentedPublicFunction:
     active: true
-    excludes: "**/test_utils/**"
+    excludes:
+      - '.*/test_utils/.*'
   UndocumentedPublicProperty:
     active: false
 
@@ -89,14 +96,24 @@ complexity:
     threshold: 4
   StringLiteralDuplication:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -146,7 +163,12 @@ exceptions:
     methodNames: 'toString,hashCode,equals,finalize'
   InstanceOfCheckForException:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
   NotImplementedDeclaration:
     active: false
   PrintStackTrace:
@@ -171,7 +193,12 @@ exceptions:
     active: false
   TooGenericExceptionCaught:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     exceptionNames:
       - ArrayIndexOutOfBoundsException
       - Error
@@ -296,39 +323,80 @@ naming:
   active: true
   ClassNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
   ConstructorParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
   EnumNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    forbiddenName: ''
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
+    forbiddenName:
+      - ''
   FunctionMaxLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     maximumFunctionNameLength: 50
   FunctionMinLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   FunctionParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverriddenFunctions: true
@@ -342,31 +410,61 @@ naming:
     ignoreOverriddenFunction: true
   ObjectPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     constantPattern: '[A-Z][_A-Z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     maximumVariableNameLength: 64
   VariableMinLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
@@ -378,10 +476,20 @@ performance:
     active: true
   ForEachOnRange:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
   SpreadOperator:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -409,7 +517,12 @@ potential-bugs:
     active: true
   LateinitUsage:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     excludeAnnotatedProperties: ""
     ignoreOnClassesPattern: ""
   MissingWhenCase:
@@ -449,11 +562,15 @@ style:
     includeLineWrapping: true
   ForbiddenComment:
     active: true
-    values: 'TODO:,FIXME:,STOPSHIP:'
+    values:
+      - 'TODO:'
+      - 'FIXME:'
+      - 'STOPSHIP:'
     allowedPatterns: ""
   ForbiddenImport:
     active: true
-    imports: ''
+    imports:
+      - ''
     forbiddenPatterns: ""
   ForbiddenVoid:
     active: true
@@ -471,8 +588,17 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    ignoreNumbers: '-1,0,1,2'
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true
@@ -574,5 +700,10 @@ style:
     active: true
   WildcardImport:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes:
+      - '.*/test/.*'
+      - '.*/androidTest/.*'
+      - '.*Test.kt'
+      - '.*Spec.kt'
+      - '.*Spek.kt'
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'

--- a/config/dependencies.gradle
+++ b/config/dependencies.gradle
@@ -1,14 +1,14 @@
 ext {
 
     compiler = [
-            java  : JavaVersion.VERSION_1_8,
-            kotlin: '1.4.10'
+            java  : JavaVersion.VERSION_11,
+            kotlin: '1.8.10'
     ]
 
     android = [
             minSdk    : 21,
-            targetSdk : 30,
-            compileSdk: 30
+            compileSdk: 33,
+            targetSdk : 33
     ]
 
     build = [
@@ -23,36 +23,41 @@ ext {
     ]
 
     gradle = [
-            gradle: "4.1.0",
+            gradle: "7.4.1",
     ]
 
     version = [
-            dagger          : '2.29.1',
+            dagger          : '2.45',
             retrofit        : '2.9.0',
-            okhttp          : '4.9.0',
-            moshi           : '1.11.0',
+            okhttp          : '4.10.0',
+            moshi           : '1.14.0',
             moshiLazyAdapter: '2.2',
-            constraintLayout: '2.0.2',
-            navigation      : '2.3.1',
-            lifecycle       : '2.2.0',
-            androidKtx      : '1.3.2',
+            constraintLayout: '2.1.4',
+            navigation      : '2.5.3',
+            lifecycle       : '2.5.1',
+            androidKtx      : '1.9.0',
+            appCompat       : '1.6.1',
             coroutines      : '1.3.9',
-            espresso        : '3.0.+',
-            chucker         : '3.3.0',
+            espresso        : '3.0.2',
+            chucker         : '3.5.2',
             gson            : '2.8.2',
-            glide           : '4.11.0',
-            ok2curl         : '0.6.0',
-            room            : '2.2.5',
-            jUnit           : '4.13.1',
+            glide           : '4.14.2',
+            ok2curl         : '0.8.0',
+            room            : '2.5.0',
+            jUnit           : '4.13.2',
             mockito         : '2.13.+',
-            lottie          : '3.4.4',
+            lottie          : '5.2.0',
             material        : '1.0.0',
-            preference      : '1.1.1',
+            preference      : '1.2.0',
             viewPager2      : '1.0.0',
-            timber          : '4.7.1',
-            spotless        : '3.27.1',
-            detekt          : '1.12.0',
-            gradleVersions  : '0.33.0'
+            timber          : '5.0.1',
+            spotless        : '6.15.0',
+            detekt          : '1.21.0',
+            gradleVersions  : '0.33.0',
+            playServices    : '18.1.0',
+            crypto          : '1.1.0-alpha03',
+            robolectric     : '4.9',
+            ktlint          : '0.40.0'
     ]
 
     dependency = [
@@ -64,6 +69,7 @@ ext {
 
             androidx = [
                     "androidx.core:core-ktx:$version.androidKtx",
+                    "androidx.appcompat:appcompat:$version.appCompat",
                     "androidx.navigation:navigation-fragment-ktx:$version.navigation",
                     "androidx.navigation:navigation-ui-ktx:$version.navigation",
                     "androidx.constraintlayout:constraintlayout:$version.constraintLayout",

--- a/config/detekt.gradle
+++ b/config/detekt.gradle
@@ -1,9 +1,9 @@
 apply plugin: "io.gitlab.arturbosch.detekt"
 
 detekt {
-    failFast = true
     parallel = true
     buildUponDefaultConfig = true
+    allRules = false
     config = files("$rootDir/config/.detekt.yml")
 
     reports {
@@ -11,4 +11,8 @@ detekt {
         xml.enabled = true
         txt.enabled = true
     }
+}
+
+dependencies {
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0")
 }

--- a/config/ktlint.gradle
+++ b/config/ktlint.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {
@@ -7,7 +7,9 @@ configurations {
 }
 
 dependencies {
-    ktlint "com.pinterest:ktlint:0.39.0"
+    def versions = rootProject.extensions.ext.version
+
+    ktlint "com.pinterest:ktlint:$versions.ktlint"
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/config/spotless.gradle
+++ b/config/spotless.gradle
@@ -1,4 +1,4 @@
-apply plugin: "com.diffplug.gradle.spotless"
+apply plugin: "com.diffplug.spotless"
 
 spotless {
 
@@ -15,7 +15,6 @@ spotless {
 
     kotlin {
         target '**/*.kt'
-        ktlint()
         trimTrailingWhitespace()
         indentWithSpaces()
         endWithNewline()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,16 @@
-# Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
+## For more details on how to configure your build environment visit
 # http://www.gradle.org/docs/current/userguide/build_environment.html
+#
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
-android.jetifier.blacklist=bcprov
-# Kotlin code style for this project: "official" or "obsolete":
+#Wed Feb 15 13:01:38 TRT 2023
 kotlin.code.style=official
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 21 17:56:49 EET 2020
+#Tue Feb 14 17:30:03 TRT 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/security/build.gradle
+++ b/security/build.gradle
@@ -7,13 +7,16 @@ apply from: "$rootDir/config/detekt.gradle"
 apply from: "$rootDir/config/ktlint.gradle"
 apply from: "$rootDir/config/spotless.gradle"
 
+
+def ext = rootProject.extensions.ext
+
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+
+    compileSdkVersion ext.android.compileSdk
 
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 30
+        minSdkVersion ext.android.minSdk
+        targetSdkVersion ext.android.targetSdk
         versionCode 1
         versionName "1.0"
 
@@ -28,28 +31,26 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility ext.compiler.java
+        targetCompatibility ext.compiler.java
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = ext.compiler.java
     }
 }
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.3.1'
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation 'com.google.android.gms:play-services-basement:17.6.0'
-    implementation 'androidx.security:security-crypto:1.1.0-alpha03'
+    def versions = rootProject.extensions.ext.version
 
-    api 'com.squareup.okhttp3:okhttp:3.12.12'
+    implementation "androidx.core:core-ktx:$versions.androidKtx"
+    implementation "androidx.appcompat:appcompat:$versions.appCompat"
+    implementation "com.google.android.gms:play-services-basement:$versions.playServices"
+    implementation "androidx.security:security-crypto:$versions.crypto"
 
-    testImplementation 'junit:junit:4.+'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
-    testImplementation 'org.mockito:mockito-inline:4.0.0'
-    testImplementation 'org.robolectric:robolectric:4.7.3'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    api "com.squareup.okhttp3:okhttp:$versions.okhttp"
+    testImplementation "junit:junit:$versions.junit"
+    testImplementation "org.robolectric:robolectric:$versions.robolectric"
+    androidTestImplementation "androidx.test.ext:junit:$versions.junit"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$versions.espresso"
 }


### PR DESCRIPTION
updated:

- gradle plugin to v7.4.1
- java compiler to Java 11
- compile & target sdks to api 33
- dependencies to their latest stable versions
- security module is now using dependencies.gradle as dependency version source.

notes:

Gradle command ktlintFormat was throwing an error beyond v0.40.0, so updated ktlint to that version instead of the latest.
Removed `ktlint()` from spotless's script since we already have it in `checkFormat` script and latest spotless version (6.15.0) is using a later version of ktlint (0.48.+) internally.